### PR TITLE
change user.authenticate to user.login to add compatibitity with ZABBIX 2.4

### DIFF
--- a/base.go
+++ b/base.go
@@ -129,10 +129,10 @@ func (api *API) CallWithError(method string, params interface{}) (response Respo
 	return
 }
 
-// Calls "user.authenticate" API method and fills api.Auth field.
+// Calls "user.login" API method and fills api.Auth field.
 func (api *API) Login(user, password string) (auth string, err error) {
 	params := map[string]string{"user": user, "password": password}
-	response, err := api.CallWithError("user.authenticate", params)
+	response, err := api.CallWithError("user.login", params)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
use user.login instead of user.authenticate, its no longer supported with ZABBIX 2.4 and user.login is avaible since ZABBIX 1.8
