### PR TITLE
Fix for zabbix version \d.\d.\d+ (2.0.13)

### DIFF
--- a/base_test.go
+++ b/base_test.go
@@ -79,7 +79,7 @@ func TestVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("Zabbix version %s", v)
-	if !regexp.MustCompile(`^\d\.\d\.\d$`).MatchString(v) {
+	if !regexp.MustCompile(`^\d\.\d\.\d+$`).MatchString(v) {
 		t.Errorf("Unexpected version: %s", v)
 	}
 }


### PR DESCRIPTION
Hello ! 
Sorry, but test does't work with zabbix 2.0.13 